### PR TITLE
ServiceHandler: Implements methods to change proxys dependencies

### DIFF
--- a/src/classes/service-handler/service-handler.cpp
+++ b/src/classes/service-handler/service-handler.cpp
@@ -28,18 +28,13 @@ void ServiceHandler::buildServiceProxy(RoutineService& userService)
 
 auto ServiceHandler::getProxyState(std::string serviceId) -> nlohmann::json
 {
-    nlohmann::json requiredState;
-
     try {
-        requiredState = m_serviceMap.at(serviceId)->reportState();
+        return m_serviceMap.at(serviceId)->reportState();
     } catch (const std::out_of_range) {
-        std::string errorMessage = "Get dependency state request from a not built service! Unknown Service = ";
-        errorMessage.append(serviceId);
+        std::string errorMessage = "Get dependency state request from a not built service! Unknown Service = " + serviceId;
 
         throw std::invalid_argument(errorMessage);
     }
-
-    return requiredState;
 }
 
 auto ServiceHandler::getAllProxyState() -> nlohmann::json
@@ -62,8 +57,7 @@ void ServiceHandler::changeDependencyState(std::string serviceId, std::string de
     try {
         m_serviceMap.at(serviceId)->m_proxyConfigs.changeDep(dependencyId, newState);
     } catch (const std::out_of_range) {
-        std::string errorMessage = "Change dependency state request from a not built service! Unknown Service = ";
-        errorMessage.append(serviceId);
+        std::string errorMessage = "Change dependency state request from a not built service! Unknown Service = " + serviceId;
 
         throw std::invalid_argument(errorMessage);
     }
@@ -74,8 +68,7 @@ void ServiceHandler::updateServiceProxy(std::string serviceId)
     try {
         m_serviceMap.at(serviceId)->autoUpdate();
     } catch (const std::out_of_range) {
-        std::string errorMessage = "Update request from a not built service! Unknown Service = ";
-        errorMessage.append(serviceId);
+        std::string errorMessage = "Update request from a not built service! Unknown Service = " + serviceId;
 
         throw std::invalid_argument(errorMessage);
     }

--- a/src/classes/service-handler/service-handler.cpp
+++ b/src/classes/service-handler/service-handler.cpp
@@ -28,7 +28,17 @@ void ServiceHandler::buildServiceProxy(RoutineService& userService)
 
 auto ServiceHandler::getProxyState(std::string serviceId) -> nlohmann::json
 {
-    nlohmann::json requiredState = m_serviceMap.at(serviceId)->reportState();
+    nlohmann::json requiredState;
+
+    try {
+        requiredState = m_serviceMap.at(serviceId)->reportState();
+    } catch (const std::out_of_range) {
+        std::string errorMessage = "Get dependency state request from a not built service! Unknown Service = ";
+        errorMessage.append(serviceId);
+
+        throw std::invalid_argument(errorMessage);
+    }
+
     return requiredState;
 }
 
@@ -41,6 +51,41 @@ auto ServiceHandler::getAllProxyState() -> nlohmann::json
     }
 
     return allStates;
+}
+
+void ServiceHandler::changeDependencyState(std::string serviceId, std::string dependencyId, ServiceProxy::ServiceState::state_t newState)
+{
+    if (dependencyId == "THIS") {
+        throw std::invalid_argument("THIS is a specially reserved dependency and don't accept outside changes of its state");
+    }
+
+    try {
+        m_serviceMap.at(serviceId)->m_proxyConfigs.changeDep(dependencyId, newState);
+    } catch (const std::out_of_range) {
+        std::string errorMessage = "Change dependency state request from a not built service! Unknown Service = ";
+        errorMessage.append(serviceId);
+
+        throw std::invalid_argument(errorMessage);
+    }
+}
+
+void ServiceHandler::updateServiceProxy(std::string serviceId)
+{
+    try {
+        m_serviceMap.at(serviceId)->autoUpdate();
+    } catch (const std::out_of_range) {
+        std::string errorMessage = "Update request from a not built service! Unknown Service = ";
+        errorMessage.append(serviceId);
+
+        throw std::invalid_argument(errorMessage);
+    }
+}
+
+void ServiceHandler::updateAllServiceProxys()
+{
+    for (auto& [serviceId, proxy] : m_serviceMap) {
+        proxy->autoUpdate();
+    }
 }
 
 void ServiceHandler::run()

--- a/src/classes/service-handler/service-handler.hpp
+++ b/src/classes/service-handler/service-handler.hpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <stdexcept>
 #include <string>
 
 class ServiceHandler {
@@ -21,6 +22,9 @@ public:
     auto getAllProxyState() -> nlohmann::json;
     void buildServiceProxy(StaticService& userService);
     void buildServiceProxy(RoutineService& userService);
+    void changeDependencyState(std::string serviceId, std::string dependencyId, ServiceProxy::ServiceState::state_t newState);
+    void updateServiceProxy(std::string serviceId);
+    void updateAllServiceProxys();
     void run();
 };
 


### PR DESCRIPTION
<!--PS: 🇧🇷/🇬🇧 It's ok to write your PR in Portuguese 😃-->

## What type of PR is this?
- [x] ✨ Feature
- [ ] 🐞 Bug Correction
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

# Changes:
<!-- Describe the main changes and the **expected behavior** (if applicable) -->
Esse pull request foi motivado pela necessidade de implementação dos testes unitátios para as "classes services". 

Durante a tentativa de implementar os testes unitários, senti uma enorme necessidade de fazer mudanças nas dependencias dos proxys contidos no interior do ServiceHandler, mas eu não havia implementado nenhuma maneira de fazer isso. Essa necessidade não apareceu durante a elaboração do ServiceHandler, pois acreditava que que essa dependencias seriam trocadas manualmente por uma outra classe agregada que teria o privilégio de amizade com as classes service. Porém, almejando testes unitários robustos percebi que não haveria mal algum em fornecer métodos públicos no ServiceHandler para fazer essas alterações, visto que estes poderão  ser utilizados também por essa classe que está por vir, eles permitirão testes unitários mais completos e noo pior dos casos, o "user" final do framework não terá acesso à classe ServiceHandler dirertamente pela classe daemon, logo não haverá "riscos".
(Service Handler e a saga continua...)

# Testing
<!--(if applicable) Tell us how to replicate the expected behavior.-->
Esse pull request compila e funciona assim como a versão anterior.
