### PR TITLE
fix: make m_configHandler public

### DIFF
--- a/include/frameworkd/classes/daemon/daemon.hpp
+++ b/include/frameworkd/classes/daemon/daemon.hpp
@@ -15,6 +15,8 @@ public:
 
     void getDaemonStatus();
 
+    auto getConfigHandler() -> ConfigHandler;
+
 private:
     ConfigHandler m_configHandler;
     ServiceHandler m_serviceHandler;

--- a/src/classes/daemon/daemon.cpp
+++ b/src/classes/daemon/daemon.cpp
@@ -22,3 +22,7 @@ void Daemon::run()
     m_serviceHandler.run();
     DBusHandler::finish();
 }
+
+auto Daemon::getConfigHandler() -> ConfigHandler {
+	return m_configHandler;
+}


### PR DESCRIPTION
This needed to be done to make the fkd work properly when a service
needs too access a certain configuration in the json


<!--PS: 🇧🇷/🇬🇧 It's ok to write your PR in portuguese 😃-->

## What type of PR is this? (check all applicable)
- [ ] ✨ Feature
- [X] 🐞 Bug Correction
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

# Changes:
<!-- Describe the main changes and the **expected behaviour** (if aplicable) -->
This needed to be done to make the fkd work properly when a service
needs too access a certain configuration in the json

# Testing
<!--(if aplicable) Tell us how to replicate the expected behaviour.-->

