### PR TITLE
fix: add better error msg when the config file was not found

### DIFF
--- a/src/utilities/config-handler/config-handler.cpp
+++ b/src/utilities/config-handler/config-handler.cpp
@@ -28,7 +28,7 @@ void ConfigHandler::read()
 {
     std::ifstream file(m_fileName);
     if (!file.is_open()) {
-        throw std::invalid_argument("Configuration file not found");
+        throw std::invalid_argument("Configuration file '"+ m_fileName + "' not found");
     }
 
     file >> ConfigHandler::m_config;


### PR DESCRIPTION
<!--PS: 🇧🇷/🇬🇧 It's ok to write your PR in portuguese 😃-->

## What type of PR is this? (check all applicable)
- [X] ✨ Feature
- [ ] 🐞 Bug Correction
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

# Changes:
<!-- Describe the main changes and the **expected behaviour** (if aplicable) -->
Gives a better error message when a file was not found
